### PR TITLE
Assert bosses and elite mobs are also asserted as dungeon mobs

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,3 +1,6 @@
-v.1.1.1
+v.1.1.3
 
-- Merged PRs
+- try fix wipe command so it works from server command line (untested)
+- removed the wipe command as its not needed now that its all automatic
+- you shouldnt be able to enter old maps after a world reload/server reboot now
+- might implement a system that checks so it only wipes the dimension if its getting too crowded

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,7 +2,7 @@
 org.gradle.jvmargs=-Xmx1G
 # --- COMMON GRADLE START ---
 # Mod Properties
-mod_version=1.1.1
+mod_version=1.1.3
 # Minecraft Versions
 minecraft_version=1.20.1
 forgeversion=47.1.43
@@ -20,10 +20,9 @@ modrinth_id=l7vS9yHb
 release_type=release
 maven_group=com.robertx22
 # Dependencies
-exile_library_version=2.1.1
+exile_library_version=2.1.2
 curios_version=5.2.0-beta.3+1.20.1
 jei_version=15.2.0.27
 wiki_toolkit_version=0.2.4
 publish_plugin_version=0.8.3
 # --- COMMON GRADLE END ---
-orbs_of_crafting_version=1.0.2

--- a/src/main/java/com/robertx22/dungeon_realm/block/MapDeviceBlock.java
+++ b/src/main/java/com/robertx22/dungeon_realm/block/MapDeviceBlock.java
@@ -102,7 +102,7 @@ public class MapDeviceBlock extends BaseEntityBlock {
             var start = DungeonMain.MAIN_DUNGEON_STRUCTURE.getStartFromCounter(count.x, count.z);
             var pos = TeleportUtils.getSpawnTeleportPos(DungeonMain.MAIN_DUNGEON_STRUCTURE, start.getMiddleBlockPosition(5));
 
-            var pdata = PlayerDataCapability.get(p);
+            //var pdata = PlayerDataCapability.get(p);
 
             var data = new DungeonMapData();
             data.item = map;
@@ -110,6 +110,7 @@ public class MapDeviceBlock extends BaseEntityBlock {
             data.z = start.z;
 
             be.pos = pos;
+            be.currentWorldUUID = DungeonMapCapability.getFromServer().data.data.uuid;
 
             be.setChanged();
 
@@ -132,7 +133,6 @@ public class MapDeviceBlock extends BaseEntityBlock {
             if (joinCurrentMap(p, be)) {
                 p.getServer().getLevel(ResourceKey.create(Registries.DIMENSION, DungeonMain.DIMENSION_KEY)).setBlock(pos.south(), DungeonEntries.MAP_DEVICE_BLOCK.get().defaultBlockState(), Block.UPDATE_ALL);
             }
-
 
 
         } catch (Exception e) {
@@ -204,8 +204,6 @@ public class MapDeviceBlock extends BaseEntityBlock {
 
         return InteractionResult.SUCCESS;
     }
-
-
 
 
     @Override

--- a/src/main/java/com/robertx22/dungeon_realm/block_entity/MapDeviceBE.java
+++ b/src/main/java/com/robertx22/dungeon_realm/block_entity/MapDeviceBE.java
@@ -4,6 +4,7 @@ import com.robertx22.dungeon_realm.item.DungeonItemNbt;
 import com.robertx22.dungeon_realm.item.relic.RelicAffixData;
 import com.robertx22.dungeon_realm.item.relic.RelicItemData;
 import com.robertx22.dungeon_realm.main.DungeonEntries;
+import com.robertx22.dungeon_realm.structure.DungeonMapCapability;
 import com.robertx22.library_of_exile.database.relic.stat.ExactRelicStat;
 import com.robertx22.library_of_exile.database.relic.stat.RelicMod;
 import net.minecraft.core.BlockPos;
@@ -25,7 +26,13 @@ public class MapDeviceBE extends BlockEntity implements ContainerListener {
     public boolean gaveMap = false;
     public BlockPos pos = null;
 
+    public String currentWorldUUID = "";
+
     public boolean isActivated() {
+        if (currentWorldUUID.isEmpty() || !currentWorldUUID.equals(DungeonMapCapability.getFromServer().data.data.uuid)) {
+            return false;
+        }
+
         return pos != null;
     }
 
@@ -89,6 +96,8 @@ public class MapDeviceBE extends BlockEntity implements ContainerListener {
         }
 
         nbt.put("inv", inv.createTag());
+        nbt.putString("uid", currentWorldUUID);
+
     }
 
     @Override
@@ -98,8 +107,8 @@ public class MapDeviceBE extends BlockEntity implements ContainerListener {
         if (pTag.contains("spawnpos")) {
             this.pos = BlockPos.of(pTag.getLong("spawnpos"));
         }
-
         inv.fromTag(pTag.getList("inv", 10)); // todo care when porting
+        this.currentWorldUUID = pTag.getString("uid");
     }
 
     // this i think allows me to make sure the inventory + block entity is dirty easily

--- a/src/main/java/com/robertx22/dungeon_realm/main/DungeonCommands.java
+++ b/src/main/java/com/robertx22/dungeon_realm/main/DungeonCommands.java
@@ -2,8 +2,6 @@ package com.robertx22.dungeon_realm.main;
 
 import com.mojang.brigadier.CommandDispatcher;
 import com.robertx22.dungeon_realm.item.relic.RelicGenerator;
-import com.robertx22.dungeon_realm.structure.DungeonMapCapability;
-import com.robertx22.dungeon_realm.structure.DungeonWorldData;
 import com.robertx22.library_of_exile.command_wrapper.CommandBuilder;
 import com.robertx22.library_of_exile.command_wrapper.PermWrapper;
 import com.robertx22.library_of_exile.command_wrapper.PlayerWrapper;
@@ -12,8 +10,6 @@ import com.robertx22.library_of_exile.database.init.LibDatabase;
 import com.robertx22.library_of_exile.database.relic.relic_rarity.RelicRarity;
 import com.robertx22.library_of_exile.database.relic.relic_type.RelicType;
 import com.robertx22.library_of_exile.utils.PlayerUtil;
-import net.minecraft.ChatFormatting;
-import net.minecraft.network.chat.Component;
 
 import java.util.Optional;
 
@@ -21,21 +17,7 @@ public class DungeonCommands {
 
 
     public static void init(CommandDispatcher d) {
-        CommandBuilder.of(DungeonMain.MODID, d, x -> {
-
-            x.addLiteral("wipe_world_data", PermWrapper.OP);
-
-            x.action(e -> {
-                var world = e.getSource().getLevel();
-
-                DungeonMapCapability.get(world).data = new DungeonWorldData();
-
-                e.getSource().getPlayer().sendSystemMessage(Component.literal(
-                        "Dungeon realm World data wiped, you should only do this when wiping the dimension's folder too! The dimension folder is in: savefolder\\dimensions\\dungeon_realm").withStyle(ChatFormatting.GREEN));
-            });
-
-        }, "Applies an item modification to the item in player's hand.");
-        
+       
 
         CommandBuilder.of(DungeonMain.MODID, d, x -> {
             PlayerWrapper PLAYER = new PlayerWrapper();

--- a/src/main/java/com/robertx22/dungeon_realm/main/DungeonMain.java
+++ b/src/main/java/com/robertx22/dungeon_realm/main/DungeonMain.java
@@ -33,6 +33,7 @@ import net.minecraft.core.BlockPos;
 import net.minecraft.data.CachedOutput;
 import net.minecraft.data.loot.LootTableProvider;
 import net.minecraft.resources.ResourceLocation;
+import net.minecraft.server.MinecraftServer;
 import net.minecraft.world.Container;
 import net.minecraft.world.entity.Entity;
 import net.minecraft.world.entity.LivingEntity;
@@ -94,7 +95,14 @@ public class DungeonMain {
             Arrays.asList(ARENA, UBER_ARENA, REWARD_ROOM),
             new DungeonMobValidator(),
             new MapDimensionConfigDefaults(3, 1)
-    );
+    ) {
+
+        @Override
+        public void clearMapDataOnFolderWipe(MinecraftServer minecraftServer) {
+            
+            DungeonMapCapability.get(minecraftServer.overworld()).data = new DungeonWorldData();
+        }
+    };
 
 
     public DungeonMain() {

--- a/src/main/java/com/robertx22/dungeon_realm/main/DungeonMobValidator.java
+++ b/src/main/java/com/robertx22/dungeon_realm/main/DungeonMobValidator.java
@@ -7,10 +7,10 @@ import net.minecraft.world.entity.LivingEntity;
 public class DungeonMobValidator extends MobValidator {
     @Override
     public boolean isValidMob(LivingEntity en) {
-        if (!DungeonEntityCapability.get(en).data.isDungeonMob) {
-            return false;
-        }
-
-        return true;
+        return DungeonEntityCapability.get(en).data.isDungeonMob ||
+                DungeonEntityCapability.get(en).data.isDungeonEliteMob ||
+                DungeonEntityCapability.get(en).data.isMiniBossMob ||
+                DungeonEntityCapability.get(en).data.isFinalMapBoss ||
+                DungeonEntityCapability.get(en).data.isUberBoss;
     }
 }

--- a/src/main/java/com/robertx22/dungeon_realm/structure/DungeonMapCapability.java
+++ b/src/main/java/com/robertx22/dungeon_realm/structure/DungeonMapCapability.java
@@ -15,6 +15,7 @@ import net.minecraftforge.common.capabilities.CapabilityToken;
 import net.minecraftforge.common.capabilities.ICapabilityProvider;
 import net.minecraftforge.common.util.INBTSerializable;
 import net.minecraftforge.common.util.LazyOptional;
+import net.minecraftforge.server.ServerLifecycleHooks;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -36,6 +37,11 @@ public class DungeonMapCapability implements ICapabilityProvider, INBTSerializab
         return entity.getServer().overworld().getCapability(INSTANCE).orElse(new DungeonMapCapability(entity));
     }
 
+    public static DungeonMapCapability getFromServer() {
+        return get(ServerLifecycleHooks.getCurrentServer().overworld());
+    }
+
+
     public DungeonWorldData data = new DungeonWorldData();
 
     @Override
@@ -54,7 +60,7 @@ public class DungeonMapCapability implements ICapabilityProvider, INBTSerializab
         try {
 
             LoadSave.Save(data, nbt, "data");
-            
+
         } catch (Exception e) {
             e.printStackTrace();
         }

--- a/src/main/java/com/robertx22/dungeon_realm/structure/DungeonMapData.java
+++ b/src/main/java/com/robertx22/dungeon_realm/structure/DungeonMapData.java
@@ -11,16 +11,12 @@ import com.robertx22.library_of_exile.main.ExileLog;
 import com.robertx22.library_of_exile.utils.RandomUtils;
 import net.minecraft.ChatFormatting;
 import net.minecraft.core.BlockPos;
-import net.minecraft.network.chat.Component;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.server.level.ServerLevel;
 import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.Block;
-import net.minecraft.world.scores.Objective;
-import net.minecraft.world.scores.Scoreboard;
-import net.minecraft.world.scores.criteria.ObjectiveCriteria;
 import net.minecraftforge.registries.ForgeRegistries;
 
 import java.util.HashMap;
@@ -137,7 +133,7 @@ public class DungeonMapData {
         // for example, if we have 43/40 mob blocks processed
         // and 0/3 elite blocks, we know all blocks have *actually* been processed, but I got the type counts wrong
         // so consider it to be complete if the total of "blocks left" equates to 0
-        if(mobBlocksLeftToProcess()
+        if (mobBlocksLeftToProcess()
                 + packBlocksLeftToProcess()
                 + eliteBlocksLeftToProcess()
                 + elitePackBlocksLeftToProcess()
@@ -154,11 +150,11 @@ public class DungeonMapData {
             return Math.min(rounded, 100);
         } else {
             // Blocks still being processed - assume the worst
-            int maxMobsLeft = ( mobBlocksLeftToProcess() * DungeonConfig.get().MOB_MAX.get() ) +
-                    ( packBlocksLeftToProcess() * DungeonConfig.get().PACK_MOB_MAX.get() ) +
-                    ( eliteBlocksLeftToProcess() * ELITE_KILL_WEIGHT) +
-                    ( elitePackBlocksLeftToProcess() * DungeonConfig.get().PACK_MOB_MAX.get() * ELITE_KILL_WEIGHT) +
-                    ( miniBossBlocksLeftToProcess() * MINI_BOSS_KILL_WEIGHT);
+            int maxMobsLeft = (mobBlocksLeftToProcess() * DungeonConfig.get().MOB_MAX.get()) +
+                    (packBlocksLeftToProcess() * DungeonConfig.get().PACK_MOB_MAX.get()) +
+                    (eliteBlocksLeftToProcess() * ELITE_KILL_WEIGHT) +
+                    (elitePackBlocksLeftToProcess() * DungeonConfig.get().PACK_MOB_MAX.get() * ELITE_KILL_WEIGHT) +
+                    (miniBossBlocksLeftToProcess() * MINI_BOSS_KILL_WEIGHT);
 
             int totalPossibleWeightedKills = mobSpawnCount + (eliteSpawnCount * ELITE_KILL_WEIGHT) + maxMobsLeft;
             int actualWeightedKills = mobKills + (eliteKills * ELITE_KILL_WEIGHT);
@@ -173,37 +169,16 @@ public class DungeonMapData {
 
     // precondition: totalChests > 0, so at least 1 has spawned
     private int calculateLootCompletionPercent() {
-            if(totalChests == 0) return 0;
-            float percentage = (lootedChests / (float) totalChests) * 100f;
-            int rounded = Math.round(percentage);
-            return Math.min(rounded, 100);
+        if (totalChests == 0) return 0;
+        float percentage = (lootedChests / (float) totalChests) * 100f;
+        int rounded = Math.round(percentage);
+        return Math.min(rounded, 100);
     }
 
     public void updateMapCompletionRarity(ServerPlayer player) {
 
         int killCompletionPercent = calculateKillCompletionPercent();
         ExileLog.get().debug(showMapData());
-
-        for (Player p : DungeonMain.MAIN_DUNGEON_STRUCTURE.getAllPlayersInMap(player.level(), player.blockPosition())) {
-
-            Scoreboard scoreboard = p.getScoreboard();
-            Objective completionPercentObjective = scoreboard.getObjective("completion_percent");
-            if(completionPercentObjective == null) {
-                completionPercentObjective = scoreboard.addObjective(
-                        "completion_percent",
-                        ObjectiveCriteria.DUMMY,
-                        Component.literal("Map Stats"),
-                        ObjectiveCriteria.RenderType.INTEGER
-                );
-            }
-
-            scoreboard.getOrCreatePlayerScore("§eKill %", completionPercentObjective).setScore(killCompletionPercent);
-            if(totalChests > 0) {
-                int lootCompletionPercent = calculateLootCompletionPercent();
-                scoreboard.getOrCreatePlayerScore("§bLoot %", completionPercentObjective).setScore(lootCompletionPercent);
-            }
-            scoreboard.setDisplayObjective(Scoreboard.DISPLAY_SLOT_SIDEBAR, completionPercentObjective);
-        }
 
         var rar = LibDatabase.MapFinishRarity().get(current_mob_kill_rarity);
         if (rar.getHigher().isPresent()) {


### PR DESCRIPTION
Due to `DungeonMobValidator` only regular mobs were allowed to drop MnS loot.
This PR expands that list, so 1) Uber bosses can drop watcher eyes 2) bosses, mini-bosses and elites are also would now drop MnS loot